### PR TITLE
Configure persistent upload directory

### DIFF
--- a/BackEnd/README.md
+++ b/BackEnd/README.md
@@ -1,0 +1,3 @@
+# BackEnd Setup
+
+This backend requires a `.env` file with at least `MONGO_URI` configured. You can also set `UPLOAD_ROOT` to change where uploaded files are stored. If `UPLOAD_ROOT` is not provided, uploads default to `BackEnd/uploads`.

--- a/BackEnd/middleware/uploadMiddleware.js
+++ b/BackEnd/middleware/uploadMiddleware.js
@@ -1,15 +1,19 @@
 const multer = require('multer');
 const path = require('path');
+const fs = require('fs');
+
+const uploadRoot = process.env.UPLOAD_ROOT || path.join(__dirname, '..', 'uploads');
 
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     // Dynamic folder: images for cover/profile/thumbnail, otherwise general uploads
     const imageOnlyFields = ['coverImage', 'defaultThumbnail', 'profileImage'];
-    if (imageOnlyFields.includes(file.fieldname)) {
-      cb(null, 'uploads/images/');
-    } else {
-      cb(null, 'uploads/');
-    }
+    const dest = imageOnlyFields.includes(file.fieldname)
+      ? path.join(uploadRoot, 'images')
+      : uploadRoot;
+
+    fs.mkdirSync(dest, { recursive: true });
+    cb(null, dest);
   },
   filename: function (req, file, cb) {
     cb(null, Date.now() + '-' + file.originalname);

--- a/BackEnd/server.js
+++ b/BackEnd/server.js
@@ -11,6 +11,8 @@ const waitlistRoutes = require('./routes/waitlistRoutes');
 const referralDemoRoute = require('./routes/referralDemoRoutes');
 const path = require('path');
 
+const uploadRoot = process.env.UPLOAD_ROOT || path.join(__dirname, 'uploads');
+
 dotenv.config();
 connectDB();
 
@@ -31,8 +33,8 @@ app.use(cors({
 }));
 
 app.use(express.json());
-app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
-app.use('/uploads/images', express.static(path.join(__dirname, 'uploads/images')));
+app.use('/uploads', express.static(uploadRoot));
+app.use('/uploads/images', express.static(path.join(uploadRoot, 'images')));
 
 app.use("/api/auth", authRoutes);
 app.use('/api/courses', courseRoutes);


### PR DESCRIPTION
## Summary
- store uploads in a configurable location via `UPLOAD_ROOT`
- serve static uploads from the same directory
- document environment variables

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in FrontEnd *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684285ff05e48330be14a633e85ffb9a